### PR TITLE
Support for mono

### DIFF
--- a/src/AsyncFriendlyStackTrace/EnvironmentUtil.cs
+++ b/src/AsyncFriendlyStackTrace/EnvironmentUtil.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace AsyncFriendlyStackTrace
+{
+    internal static class EnvironmentUtil
+    {
+        // see http://www.mono-project.com/docs/gui/winforms/porting-winforms-applications/#runtime-conditionals
+        internal static bool IsRunningOnMono()
+        {
+            return Type.GetType("Mono.Runtime") != null;
+        }
+    }
+}

--- a/src/AsyncFriendlyStackTrace/ExceptionExtensions.cs
+++ b/src/AsyncFriendlyStackTrace/ExceptionExtensions.cs
@@ -118,7 +118,7 @@ namespace AsyncFriendlyStackTrace
             return remoteStackTrace + stackTrace;
         }
 		
-		// see http://www.mono-project.com/docs/gui/winforms/porting-winforms-applications/#runtime-conditionals
+	// see http://www.mono-project.com/docs/gui/winforms/porting-winforms-applications/#runtime-conditionals
         private static bool IsRunningOnMono()
         {
             return Type.GetType("Mono.Runtime") != null;

--- a/src/AsyncFriendlyStackTrace/ExceptionExtensions.cs
+++ b/src/AsyncFriendlyStackTrace/ExceptionExtensions.cs
@@ -14,7 +14,7 @@ namespace AsyncFriendlyStackTrace
         private const string AsyncStackTraceExceptionData = "AsyncFriendlyStackTrace";
 
         private static Func<Exception, string> GetStackTraceString => 
-            ReflectionUtil.GenerateGetField<Exception, string>(IsRunningOnMono() ? "stack_trace" : "_stackTraceString");
+            ReflectionUtil.GenerateGetField<Exception, string>(EnvironmentUtil.IsRunningOnMono() ? "stack_trace" : "_stackTraceString");
 
         private static readonly Func<Exception, string> GetRemoteStackTraceString =
             ReflectionUtil.GenerateGetField<Exception, string>("_remoteStackTraceString");
@@ -116,12 +116,6 @@ namespace AsyncFriendlyStackTrace
                              new StackTrace(exception, true).ToAsyncString();
             var remoteStackTrace = GetRemoteStackTraceString(exception);
             return remoteStackTrace + stackTrace;
-        }
-		
-	// see http://www.mono-project.com/docs/gui/winforms/porting-winforms-applications/#runtime-conditionals
-        private static bool IsRunningOnMono()
-        {
-            return Type.GetType("Mono.Runtime") != null;
         }
     }
 }

--- a/src/AsyncFriendlyStackTrace/ExceptionExtensions.cs
+++ b/src/AsyncFriendlyStackTrace/ExceptionExtensions.cs
@@ -13,8 +13,8 @@ namespace AsyncFriendlyStackTrace
         private const string AggregateExceptionFormatString = "{0}{1}---> (Inner Exception #{2}) {3}{4}{5}";
         private const string AsyncStackTraceExceptionData = "AsyncFriendlyStackTrace";
 
-        private static readonly Func<Exception, string> GetStackTraceString =
-            ReflectionUtil.GenerateGetField<Exception, string>("_stackTraceString");
+        private static Func<Exception, string> GetStackTraceString => 
+            ReflectionUtil.GenerateGetField<Exception, string>(IsRunningOnMono() ? "stack_trace" : "_stackTraceString");
 
         private static readonly Func<Exception, string> GetRemoteStackTraceString =
             ReflectionUtil.GenerateGetField<Exception, string>("_remoteStackTraceString");
@@ -116,6 +116,12 @@ namespace AsyncFriendlyStackTrace
                              new StackTrace(exception, true).ToAsyncString();
             var remoteStackTrace = GetRemoteStackTraceString(exception);
             return remoteStackTrace + stackTrace;
+        }
+		
+		// see http://www.mono-project.com/docs/gui/winforms/porting-winforms-applications/#runtime-conditionals
+        private static bool IsRunningOnMono()
+        {
+            return Type.GetType("Mono.Runtime") != null;
         }
     }
 }


### PR DESCRIPTION
As discussed in #3, I introduced special handling for Mono, because a private field in System.Exception is named differently that in standard .NET.

I went with runtime conditional (http://www.mono-project.com/docs/gui/winforms/porting-winforms-applications/#runtime-conditionals) so that the same binary works on both platforms.
