### PR TITLE
Dependencies should work with RC1 now

### DIFF
--- a/src/AsyncFriendlyStackTrace.Test/project.json
+++ b/src/AsyncFriendlyStackTrace.Test/project.json
@@ -27,24 +27,28 @@
     },
     "dotnet5.4": {
       "dependencies": {
-        "Microsoft.CSharp": "4.0.1-beta-23516",
+        "Microsoft.CSharp": "4.0.0",
         "System.Collections": "4.0.11-beta-23516",
         "System.Console": "4.0.0-beta-23516",
         "System.Linq": "4.0.1-beta-23516",
         "System.Threading": "4.0.11-beta-23516",
+        "System.Threading.Tasks":  "4.0.11-beta-23516",
         "System.Runtime.Serialization.Xml": "4.1.0-beta-23516",
-        "System.Xml.ReaderWriter": "4.0.11-beta-23516"
+        "System.Xml.ReaderWriter": "4.0.11-beta-23516",
+        "System.ObjectModel": "4.0.0"
       }
     },
     "dnxcore50": {
       "dependencies": {
-        "Microsoft.CSharp": "4.0.1-beta-23516",
+        "Microsoft.CSharp": "4.0.0",
         "System.Collections": "4.0.11-beta-23516",
         "System.Console": "4.0.0-beta-23516",
         "System.Linq": "4.0.1-beta-23516",
         "System.Threading": "4.0.11-beta-23516",
+        "System.Threading.Tasks": "4.0.11-beta-23516",
         "System.Runtime.Serialization.Xml": "4.1.0-beta-23516",
-        "System.Xml.ReaderWriter": "4.0.11-beta-23516"
+        "System.Xml.ReaderWriter": "4.0.11-beta-23516",
+        "System.ObjectModel": "4.0.0"
       }
     }
   }

--- a/src/AsyncFriendlyStackTrace/project.json
+++ b/src/AsyncFriendlyStackTrace/project.json
@@ -10,24 +10,26 @@
     "net451": { },
     "dotnet5.4": {
       "dependencies": {
-        "Microsoft.CSharp": "4.0.1-beta-23516",
+        "Microsoft.CSharp": "4.0.0",
         "System.Collections": "4.0.11-beta-23516",
         "System.Linq": "4.0.1-beta-23516",
         "System.Runtime": "4.0.21-beta-23516",
         "System.Threading": "4.0.11-beta-23516",
         "System.Diagnostics.StackTrace": "4.0.1-beta-23516",
-        "System.Reflection": "4.1.0-beta-23516"
+        "System.Reflection": "4.1.0-beta-23516",
+        "System.ObjectModel": "4.0.0"
       }
     },
     "dnxcore50": {
       "dependencies": {
-        "Microsoft.CSharp": "4.0.1-beta-23516",
+        "Microsoft.CSharp": "4.0.0",
         "System.Collections": "4.0.11-beta-23516",
         "System.Linq": "4.0.1-beta-23516",
         "System.Runtime": "4.0.21-beta-23516",
         "System.Threading": "4.0.11-beta-23516",
         "System.Diagnostics.StackTrace": "4.0.1-beta-23516",
-        "System.Reflection": "4.1.0-beta-23516"
+        "System.Reflection": "4.1.0-beta-23516",
+        "System.ObjectModel": "4.0.0"
       }
     }
   }


### PR DESCRIPTION
I played around to get the dependencies for all frameworks to compile on my machine, that only has RC1 installed. I don't think that any support for RC2 should break. Please let me know what you think.
